### PR TITLE
Add GitHub CI via Nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+      - name: Usage help
+        run: nix-shell --pure --run "git_recycle_bin.py --help"
+      - name: Just list
+        run: nix-shell --pure --run "just --list"
+      - name: Unit tests
+        env:
+          TZ: Europe/Copenhagen
+        run: nix-shell --pure --run "just unittest"


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run unit tests via Nix
- run help and just list commands for parity with GitLab CI
- set `TZ` so tests expecting CEST pass

## Testing
- `TZ=Europe/Copenhagen PYTHONPATH=$PWD:$PWD/src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497d349778832bbd137538e8abcece