### PR TITLE
Pin nixpkgs in default.nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+env:
+  NIX_PATH: "nixpkgs=channel:nixos-24.05"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,7 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? (import (builtins.fetchTarball {
+    url = "https://github.com/nixos/nixpkgs/tarball/24.05";
+    sha256 = "1lr1h35prqkd1mkmzriwlpvxcb34kmhc9dnr48gkm8hh089hifmx";
+  }) {} ) }:
 
 pkgs.python311Packages.buildPythonApplication rec {
   pname = "git-recycle-bin";


### PR DESCRIPTION
## Summary
- keep default.nix independent of NIX_PATH by pinning nixpkgs
- set NIX_PATH in CI for all jobs

## Testing
- `nix-shell --pure --run "just unittest"`


------
https://chatgpt.com/codex/tasks/task_e_6849ecf7e5e0832bb9454d5510326b6d