### PR TITLE
Fix tree_size NameError and add tests

### DIFF
--- a/src/rbgit.py
+++ b/src/rbgit.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import subprocess
+import re
 
 class RbGit:
     def __init__(self, printer, rbgit_dir=None, rbgit_work_tree=None):

--- a/tests/test_rbgit.py
+++ b/tests/test_rbgit.py
@@ -1,0 +1,17 @@
+import pytest
+
+from rbgit import RbGit
+
+class DummyRbGit:
+    def cmd(self, *args, **kwargs):
+        if args[:2] == ("ls-tree", "-lr"):
+            return (
+                "100644 blob aaaaaa 123\tfile1\n"
+                "100644 blob bbbbbb 456\tfile2\n"
+            )
+        raise RuntimeError("Unexpected command")
+
+def test_tree_size_sum():
+    dummy = DummyRbGit()
+    size = RbGit.tree_size(dummy, "HEAD")
+    assert size == 579


### PR DESCRIPTION
## Summary
- add missing `re` import to `rbgit.py`
- add tests for `tree_size` covering expected behavior

## Testing
- `PYTHONPATH=$PWD:$PWD/src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849da745bec832b88e6201650525a17