### PR TITLE
Update invalid date test to check error message

### DIFF
--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -52,10 +52,10 @@ def test_relative_date():
     assert grb.date_fuzzy2expiryformat("next month") == grb.date_fuzzy2expiryformat("now in 1 month")
 
 def test_invalid_date():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="invalid datetime input"):
         grb.date_fuzzy2expiryformat("invalid")
-    with pytest.raises(ValueError):
-        assert grb.date_fuzzy2expiryformat("Mon, 32 Feb 1994 21:21:42 GMT") == "there is no Feb 32"
+    with pytest.raises(ValueError, match="invalid datetime input"):
+        grb.date_fuzzy2expiryformat("Mon, 32 Feb 1994 21:21:42 GMT")
 
 def test_parse_expire_datetime():
     p = "artifact/expire/"


### PR DESCRIPTION
## Summary
- tweak `test_invalid_date` to verify `invalid datetime input` error

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849da9d1f08832b817602266b3f174c