### PR TITLE
Run pytest in Nix builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,15 @@ pkgs.python311Packages.buildPythonApplication rec {
     pytest
   ];
 
+  checkInputs = with pkgs.python311Packages; [ pytest ];
+
+  checkPhase = ''
+    runHook preCheck
+    export PYTHONPATH="$PYTHONPATH:$PWD:$PWD/src"
+    python -m pytest -vv
+    runHook postCheck
+  '';
+
   postInstall = ''
     install -Dm755 ${./aux/git_add_ssh_remote.sh} $out/bin/git_add_ssh_remote.sh
   '';


### PR DESCRIPTION
## Summary
- run `python -m pytest` inside the Nix `checkPhase`
- ensure PYTHONPATH is set so tests can import project modules

## Testing
- `nix-shell shell.nix --pure --run "just unittest"`

------
https://chatgpt.com/codex/tasks/task_e_684b3c9a82e0832b9debe02020340fa2