### PR TITLE
Expand unit test coverage

### DIFF
--- a/tests/test_arg_parser.py
+++ b/tests/test_arg_parser.py
@@ -36,3 +36,14 @@ def test_parse_args_push():
 def test_parse_args_force_tag_requires_force_branch():
     res = run_parse_args(['push', 'https://example.com', '--path', '/tmp/foo', '--name', 'bar', '--force-tag'])
     assert res is None
+
+
+def test_parse_args_list_name():
+    args = run_parse_args(['list', 'https://example.com', '--name', 'foo'])
+    assert args.command == 'list'
+    assert args.query == ('name', 'foo')
+
+
+def test_parse_args_missing_remote():
+    with pytest.raises(SystemExit):
+        run_parse_args(['list'])

--- a/tests/test_commit_msg.py
+++ b/tests/test_commit_msg.py
@@ -35,3 +35,28 @@ def test_emit_commit_msg_redacts_url():
     msg = emit_commit_msg(d)
     assert "artifact: repo.git@abcdef1234: artifact @(Commit title)" in msg
     assert "src-git-repo-url: https://user:REDACTED@host/repo.git" in msg
+
+
+def test_emit_commit_msg_truncates_title_and_handles_missing_changeid():
+    d = {
+        'artifact_name': 'name',
+        'src_repo': 'repo.git',
+        'src_sha_short': 'abc',
+        'src_sha_title': 'T' * 50,
+        'artifact_mime': 'text/plain',
+        'artifact_relpath_nca': 'p',
+        'artifact_relpath_src': 'p',
+        'src_sha': 'a' * 40,
+        'src_sha_msg': 'Message without id',
+        'src_time_author': 'Thu, 01 Jan 1970 00:00:00 +0000',
+        'src_time_commit': 'Thu, 01 Jan 1970 00:00:00 +0000',
+        'src_branch': 'main',
+        'src_repo_url': 'url',
+        'src_commits_ahead': '',
+        'src_commits_behind': '',
+        'src_status': '',
+    }
+    msg = emit_commit_msg(d)
+    truncated = 'T' * 27 + '...'
+    assert truncated in msg
+    assert 'src-git-commit-changeid:' not in msg

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+import list as list_mod
+
+
+def test_remote_artifacts(monkeypatch):
+    # patch util.exec to return known sha
+    monkeypatch.setattr(list_mod, 'exec', lambda cmd: 'abcd')
+
+    def fake_cmd(*args, **kwargs):
+        if args[:3] == ('ls-remote', '--refs', 'remote'):
+            return 'm1 refs/artifact/meta-for-commit/abcd/sha1\nm2 refs/artifact/meta-for-commit/abcd/sha2\n'
+        raise AssertionError('unexpected')
+
+    dummy = SimpleNamespace(cmd=fake_cmd)
+    res = list_mod.remote_artifacts(dummy, 'remote')
+    assert res == [('m1', 'sha1'), ('m2', 'sha2')]
+
+
+def test_filter_artifacts_by_name_and_path(monkeypatch):
+    msgs = {
+        'm1': 'artifact-name: foo\nsrc-git-relpath: path1',
+        'm2': 'artifact-name: bar\nsrc-git-relpath: path2',
+    }
+
+    def fake_fetch(remote, ref):
+        return msgs[ref]
+
+    dummy = SimpleNamespace(fetch_cat_pretty=lambda r, ref: fake_fetch(r, ref))
+    artifacts = [('m1', 'sha1'), ('m2', 'sha2')]
+
+    filtered = list_mod.filter_artifacts(
+        dummy, 'r', 'foo', artifacts, list_mod.filter_funcs['name']
+    )
+    assert filtered == [('m1', 'sha1')]
+
+    filtered = list_mod.filter_artifacts(
+        dummy, 'r', 'path2', artifacts, list_mod.filter_funcs['path']
+    )
+    assert filtered == [('m2', 'sha2')]

--- a/tests/test_rbgit.py
+++ b/tests/test_rbgit.py
@@ -15,3 +15,44 @@ def test_tree_size_sum():
     dummy = DummyRbGit()
     size = RbGit.tree_size(dummy, "HEAD")
     assert size == 579
+
+
+def test_remote_already_has_ref():
+    class D:
+        def cmd(self, *args):
+            if args[0] == 'ls-remote':
+                return 'sha\tref' if args[-1] == 'ref' else ''
+            raise RuntimeError('bad')
+
+    dummy = D()
+    assert RbGit.remote_already_has_ref(dummy, 'origin', 'ref') is True
+    assert RbGit.remote_already_has_ref(dummy, 'origin', 'missing') is False
+
+
+def test_fetch_current_tag_value():
+    class D:
+        def cmd(self, *args):
+            if args[:3] == ('ls-remote', '--tags', 'origin'):
+                return 'a1\trefs/tags/v1\nb2\trefs/tags/v2'
+            raise RuntimeError('bad')
+
+    dummy = D()
+    assert RbGit.fetch_current_tag_value(dummy, 'origin', 'v2') == 'b2'
+
+
+def test_fetch_cat_pretty():
+    calls = []
+
+    class D:
+        def cmd(self, *args, **kwargs):
+            calls.append(args)
+            if args[0] == 'fetch':
+                return ''
+            if args[:2] == ('cat-file', '-p'):
+                return 'content'
+            raise RuntimeError('bad')
+
+    dummy = D()
+    res = RbGit.fetch_cat_pretty(dummy, 'origin', 'ref')
+    assert calls[0] == ('fetch', 'origin', 'ref')
+    assert res == 'content'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,31 @@
+import subprocess
+from util import exec, exec_nostderr
+
+
+def test_exec_env(monkeypatch):
+    called = {}
+
+    def fake_check_output(cmd, env=None, text=None, stderr=None):
+        called['cmd'] = cmd
+        called['env'] = env
+        called['stderr'] = stderr
+        return 'out'
+
+    monkeypatch.setattr(subprocess, 'check_output', fake_check_output)
+    res = exec(['echo', 'hi'], env={'FOO': 'BAR'})
+    assert res == 'out'
+    assert called['cmd'] == ['echo', 'hi']
+    assert called['env']['FOO'] == 'BAR'
+    assert called['stderr'] is None
+
+
+def test_exec_nostderr(monkeypatch):
+    called = {}
+
+    def fake_check_output(cmd, env=None, text=None, stderr=None):
+        called['stderr'] = stderr
+        return ''
+
+    monkeypatch.setattr(subprocess, 'check_output', fake_check_output)
+    exec_nostderr(['echo'])
+    assert called['stderr'] is subprocess.DEVNULL

--- a/tests/test_util_date.py
+++ b/tests/test_util_date.py
@@ -1,6 +1,13 @@
 import datetime
 from dateutil.tz import tzlocal
-from util_date import parse_fuzzy_time, parse_expire_date, date_formatted2unix, format_timespan, DATE_FMT_GIT
+from util_date import (
+    parse_fuzzy_time,
+    parse_expire_date,
+    date_formatted2unix,
+    format_timespan,
+    DATE_FMT_GIT,
+    date_fuzzy2expiryformat,
+)
 
 
 def test_parse_fuzzy_time_now():
@@ -22,3 +29,18 @@ def test_format_timespan():
     a = datetime.datetime(2023,1,1, tzinfo=tzlocal())
     b = datetime.datetime(2023,1,2,3,4, tzinfo=tzlocal())
     assert format_timespan(a, b).strip() == '1days  3h  4m'
+
+
+def test_date_fuzzy2expiryformat_absolute():
+    s = '2024-01-02 12:00 UTC'
+    res = date_fuzzy2expiryformat(s)
+    parsed = parse_expire_date(res)
+    assert parsed['date'] == '2024-01-02'
+    assert parsed['time'] is not None
+
+
+def test_date_fuzzy2expiryformat_relative():
+    res = date_fuzzy2expiryformat('in 1 day')
+    parsed = parse_expire_date(res)
+    assert parsed['date'] is not None
+

--- a/tests/test_util_string.py
+++ b/tests/test_util_string.py
@@ -1,4 +1,11 @@
-from util_string import remove_empty_lines, sanitize_slashes, sanitize_branch_name
+from util_string import (
+    remove_empty_lines,
+    sanitize_slashes,
+    sanitize_branch_name,
+    trim_all_lines,
+    prefix_lines,
+    string_trunc_ellipsis,
+)
 
 
 def test_remove_empty_lines():
@@ -14,3 +21,20 @@ def test_sanitize_branch_name():
     assert sanitize_branch_name('foo bar') == 'foo_bar'
     assert sanitize_branch_name('/start') == '_start'
     assert sanitize_branch_name('foo..bar') == 'foo.bar'
+
+
+def test_trim_all_lines():
+    inp = '  a\n b  '
+    expected = 'a\nb'
+    assert trim_all_lines(inp) == expected
+
+
+def test_prefix_lines():
+    text = 'a\nb'
+    assert prefix_lines(text, 'p: ') == 'p: a\np: b'
+
+
+def test_string_trunc_ellipsis():
+    long = 'abcdefg'
+    assert string_trunc_ellipsis(10, long) == long
+    assert string_trunc_ellipsis(5, long) == 'ab...'


### PR DESCRIPTION
## Summary
- extend arg parser tests
- add more commit_msg tests
- test more rbgit utilities
- add helper tests for util functions
- cover list helpers
- more util_date and util_string tests

## Testing
- `nix-shell shell.nix --pure --run "just unittest"`

------
https://chatgpt.com/codex/tasks/task_e_684b402da558832baa1913de34015140