### PR TITLE
Fix markdown linting errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,41 +1,61 @@
 # Repo Guidelines for Codex Agents
 
-This project provides a collection of Python scripts and utilities for managing artifacts in a git repository.  It uses Nix for reproducible development environments but should remain runnable outside of Nix as a normal Python package.
+This project provides a collection of Python scripts and utilities for
+managing artifacts in a git repository. It uses Nix for reproducible
+development environments but should remain runnable outside of Nix as a
+normal Python package.
 
 ## Project Structure
+
 The repository is organised into a few key folders:
+
 - `src/` contains the application code and executable entrypoints.
 - `tests/` holds unit and future integration tests.
 - `demos/` shows practical usage of the tools.
 - `aux/` stores helper scripts used by the build.
 
 ## Coding Conventions
+
 - Follow PEP 8 style with four-space indentation and descriptive names.
 - Use type hints where sensible and keep functions short and readable.
 - Prefer standard library modules over additional dependencies when possible.
 
 ## General Conventions for AGENTS.md Implementation
-- Keep this document in sync with the code base. Update guidelines alongside feature or behaviour changes.
-- Clarify any new requirements or conventions in this file so agents know how to contribute.
+
+- Keep this document in sync with the code base. Update guidelines alongside
+  feature or behaviour changes.
+- Clarify any new requirements or conventions in this file so agents know how to
+  contribute.
 
 ## Testing Requirements
+
 - Preferred: `nix-shell shell.nix --pure --run "just unittest"`.
-- Non-Nix: install dependencies from `setup.py` and run `pytest` with `PYTHONPATH=$PWD:$PWD/src`.
-- Integration tests comparing HEAD with prior tagged releases must pass before merging breaking behaviour changes.
+- Non-Nix: install dependencies from `setup.py` and run `pytest` with
+  `PYTHONPATH=$PWD:$PWD/src`.
+- Integration tests comparing HEAD with prior tagged releases must pass before
+  merging breaking behaviour changes.
 
 ## Environment
+
 - Code should run with Python 3.11+. Avoid Nix-specific runtime assumptions.
 - Ensure the project remains installable with `pip install .`.
 
 ## Style and Quality
-- Keep the code base robust and industrial readable. Use type hints and descriptive names.
-- Avoid breaking changes. Introduce integration tests comparing HEAD with previous tagged releases when altering behaviour.
-- Keep documentation and design notes in sync with the implementation to avoid drift.
+
+- Keep the code base robust and industrial readable. Use type hints and
+  descriptive names.
+- Avoid breaking changes. Introduce integration tests comparing HEAD with
+  previous tagged releases when altering behaviour.
+- Keep documentation and design notes in sync with the implementation to avoid
+  drift.
 
 ## Pull Request Guidelines
+
 - Keep PRs focused and include a summary of changes and testing steps.
 - Ensure programmatic checks pass locally before opening a PR.
 
 ## Programmatic Checks
-- Run `nix-shell shell.nix --pure --run "just unittest"` and ensure all tests succeed.
+
+- Run `nix-shell shell.nix --pure --run "just unittest"` and ensure all tests
+  succeed.
 - Validate that documentation updates accompany code changes to prevent drift.

--- a/aux/git_add_ssh_remote.sh
+++ b/aux/git_add_ssh_remote.sh
@@ -58,4 +58,4 @@ else
     git remote add "${REMOTE_NAME}_ssh" "$ssh_url" 2>/dev/null || true
 fi
 
-echo "Remote '${REMOTE_NAME}_ssh' added: $(git remote get-url ${REMOTE_NAME}_ssh)" 1>&2
+echo "Remote '${REMOTE_NAME}_ssh' added: $(git remote get-url "${REMOTE_NAME}_ssh")" 1>&2

--- a/issues/0001-git-notes-integration.md
+++ b/issues/0001-git-notes-integration.md
@@ -1,14 +1,22 @@
 # Git notes integration for artifact discovery
 
 ## Background
-`git notes` allows attaching auxiliary metadata to commits without changing commit hashes. The project now uses git notes to advertise available binary artifacts.
+
+`git notes` allows attaching auxiliary metadata to commits without changing
+commit hashes. The project now uses git notes to advertise available binary
+artifacts.
 
 ## Proposed design
-- Maintain a dedicated notes namespace such as `refs/notes/artifact/<TARGET>` or `refs/notes/artifact/<BIN_REMOTE>/<TARGET>`. Each note will attach to the corresponding source commit SHA.
+
+- Maintain a dedicated notes namespace such as
+  `refs/notes/artifact/<TARGET>` or `refs/notes/artifact/<BIN_REMOTE>/<TARGET>`.
+  Each note will attach to the corresponding source commit SHA.
 - Note contents will be sorted lines of simple JSON with fields:
   `{date:<BIN_SHA_COMMIT_DATE>, sha:<BIN_SHA>, target:<TARGET>, ttl:<TTL>, remote:<BIN_REMOTE>}`
-- Clients can fetch and display these notes to discover artifacts related to a source commit without knowing the binary remote upfront.
-- Additional helper commands will be added to create and read these notes when pushing or listing artifacts.
+- Clients can fetch and display these notes to discover artifacts related to a
+  source commit without knowing the binary remote upfront.
+- Additional helper commands will be added to create and read these notes when
+  pushing or listing artifacts.
 
-This issue tracked implementation of the git notes scheme described above and in `design_notes.txt`.
-Implementation landed in commit 5ef2128.
+This issue tracked implementation of the git notes scheme described above and in
+`design_notes.txt`. Implementation landed in commit 5ef2128.

--- a/justfile
+++ b/justfile
@@ -13,3 +13,11 @@ mod push 'demos/push.justfile'
 mod list 'demos/list.justfile'
 mod clean 'demos/clean.justfile'
 mod download 'demos/download.justfile'
+
+# Lint shell scripts with shellcheck
+shellcheck:
+    shellcheck $(git ls-files '*.sh')
+
+# Lint Markdown files with markdownlint
+mdlint:
+    markdownlint $(git ls-files '*.md')

--- a/readme.md
+++ b/readme.md
@@ -1,86 +1,121 @@
 # What?
-This project provides means for pushing artifacts from a git source repo to a git binary repo.
 
-Say you/CI build an app; now you can publish your binary to git! Not to your same source code repo, but another *binary* repo.
+This project provides means for pushing artifacts from a git source repository
+to a git binary repository.
 
+Say you or CI builds an app; now you can publish your binary to git! Not to your
+same source code repo, but another *binary* repo.
 
-# Why?
-Unlike many artifact management systems out there, the artifacts published here will:
- - Have full traceability back to their original source code.
-- Support expiry and garbage collection - achieved via git gc of orphan branches with absolute expiry date in their ref.
+## Why?
+
+Unlike many artifact management systems out there, the artifacts published here
+will:
+
+- Have full traceability back to their original source code.
+- Support expiry and garbage collection - achieved via git gc of orphan branches
+  with absolute expiry date in their ref.
 - Prolong expiry (absolute or indefinite) via simple git commands.
-- Permit discoverability of available artifacts via `git notes`.
-  Implemented as described in [issue #1](issues/0001-git-notes-integration.md).
+- Permit discoverability of available artifacts via `git notes`. Implemented as
+  described in [issue #1](issues/0001-git-notes-integration.md).
 
+## Usage
 
-# Usage
-* Locally or CI-side, this tool creates and pushes artifacts, see `--help` and examples below.
-* Garbage collection of expired artifacts is done at server-side.
-* GitHub Actions in `.github/workflows/ci.yml` run tests and demo commands.
+- Locally or CI-side, this tool creates and pushes artifacts, see `--help` and
+  examples below.
+- Garbage collection of expired artifacts is done server-side.
+- GitHub Actions in `.github/workflows/ci.yml` run tests and demo commands.
 
+### Schema
 
-## Schema
-Artifacts come with meta-data, for {expiry, traceability, audit, placement} purposes. \
-Meta-data is stored as trailer fields in the commit message, forming a schema, e.g.:
+Artifacts come with meta-data for expiry, traceability, audit and placement
+purposes. Meta-data is stored as trailer fields in the commit message, forming a
+schema, for example:
 
-* `artifact-schema-version: 1` : Integer. The version of the schema.
-* `artifact-name: Aurora-RST-Documentation` : String. Name of the artifact.
-* `artifact-mime-type: directory` : String or tuple. MIME type of the artifact.
-  - One of {[`mimetypes.guess_type()`](https://docs.python.org/3/library/mimetypes.html#mimetypes.guess_type), `directory`, `link`, `mount`, `unknown`}.
-* `artifact-tree-prefix: obj/doc/html` : String. Files in this artifact commit all share this directory-prefix.
-  - Either `.` or some directory-prefix. (A directory-prefix can make merges of artifact-commits conflict-free)
-* `src-git-relpath: ../obj/doc/html` : String. Relative path to artifact from source-git's root.
-  - Leading `../ ` means artifact resided outside the source-git.
-* `src-git-commit-title: rf: twister wrapper WIP` : String. Artifact was built from this commit in source git repo.
-* `src-git-commit-sha: ed6267ee5b84c894fc8490d93db0525fb2f167eb` : String. Artifact was built from this commit in source git repo.
-* `src-git-commit-changeid: Ie3eb7af86c3e578d2c18631f15cf0a12e7d0f80d` : String. Artifact was built from this commit in source git repo. Optional.
-* `src-git-commit-time-author: Wed, 21 Jun 2023 14:13:31 +0200` : Date. Artifact was built from this commit in source git repo.
-* `src-git-commit-time-commit: Wed, 21 Jun 2023 15:42:49 +0200` : Date. Artifact was built from this commit in source git repo.
-* `src-git-branch: feature/wrk_le_audio_7.0` : String. Locally-checked out branch in source git repo or `Detached HEAD`.
-* `src-git-repo-name: firmware` : String. Basename of `src-git-repo-url`.
-* `src-git-repo-url: ssh://gerrit.ci.demant.com:29418/firmware` : String. URL of remote in source git repo.
-* `src-git-commits-ahead: ?`: Integer or `?`. How many commits source git repo branch was locally ahead of its remote upstream tracking branch.
-* `src-git-commits-behind: ?`: Integer or `?`. How many commits source git repo branch was locally behind of its remote upstream tracking branch.
-* `src-git-status: clean` : String or strings. Either `clean` or list of locally {modified, deleted} files in source git repo. Untracked files are ignored.
+- `artifact-schema-version: 1` : Integer. The version of the schema.
+- `artifact-name: Aurora-RST-Documentation` : String. Name of the artifact.
+- `artifact-mime-type: directory` : String or tuple. MIME type of the artifact.
+  - One of
+    [`mimetypes.guess_type()`](https://docs.python.org/3/library/mimetypes.html#mimetypes.guess_type),
+    `directory`, `link`, `mount`, `unknown`.
+- `artifact-tree-prefix: obj/doc/html` : String. Files in this artifact commit
+  all share this directory prefix.
+  - Either `.` or some directory prefix. A directory prefix can make merges of
+    artifact commits conflict-free.
+- `src-git-relpath: ../obj/doc/html` : String. Relative path to the artifact from
+  the source git root.
+  - Leading `../` means the artifact resided outside the source git.
+- `src-git-commit-title: rf: twister wrapper WIP` : String. Artifact was built
+  from this commit in the source git repo.
+- `src-git-commit-sha: ed6267ee5b84c894fc8490d93db0525fb2f167eb` : String.
+  Artifact was built from this commit in the source git repo.
+- `src-git-commit-changeid: Ie3eb7af86c3e578d2c18631f15cf0a12e7d0f80d` : String.
+  Artifact was built from this commit in the source git repo. Optional.
+- `src-git-commit-time-author: Wed, 21 Jun 2023 14:13:31 +0200` : Date. Artifact
+  was built from this commit in the source git repo.
+- `src-git-commit-time-commit: Wed, 21 Jun 2023 15:42:49 +0200` : Date. Artifact
+  was built from this commit in the source git repo.
+- `src-git-branch: feature/wrk_le_audio_7.0` : String. Locally checked out branch
+  in the source git repo or `Detached HEAD`.
+- `src-git-repo-name: firmware` : String. Basename of `src-git-repo-url`.
+- `src-git-repo-url: ssh://gerrit.ci.demant.com:29418/firmware` : String. URL of
+  the remote in the source git repo.
+- `src-git-commits-ahead: ?` : Integer or `?`. How many commits the source git
+  repo branch was locally ahead of its remote upstream tracking branch.
+- `src-git-commits-behind: ?` : Integer or `?`. How many commits the source git
+  repo branch was locally behind its remote upstream tracking branch.
+- `src-git-status: clean` : String or strings. Either `clean` or a list of
+  locally modified or deleted files in the source git repo. Untracked files are
+  ignored.
 
-This scheme captures only what is intrinsically tied to the artifact and the sources it comes from.
-Adding further meta-data should be carefully considered, so as to not compromise the repeatability/_stability_ of the artifact's commit SHA.
+This scheme captures only what is intrinsically tied to the artifact and the
+sources it comes from. Adding further meta-data should be carefully considered
+so as not to compromise the repeatability or stability of the artifact's commit
+SHA.
 
+#### Other schema ideas
 
-### Other schema ideas
-It may be tempting to extend the schema above with further convenient meta-data, see below for more ideas.
-However, adding such _convenient_ meta-data means we mix-in ever-changing non-reproducible machine-specific side-effects - making the SHA _unstable_.
-These could still be useful but do no belong in the artifact's commit message; would fit better as a `git-note` attached to the artifact's commitish or treeish -- this remains as possible future work.
+It may be tempting to extend the schema above with further convenient meta-data,
+see below for more ideas. However, adding such convenient meta-data means we mix
+in ever-changing, non-reproducible, machine-specific side effects, making the
+SHA unstable. These could still be useful but do not belong in the artifact's
+commit message; they would fit better as a `git-note` attached to the artifact's
+commitish or treeish -- this remains as possible future work.
 
-* `artifact-outputs`: List of files/artifacts generated. Would give more insight into what's included beyond just the tree prefix.
-* `artifact-dependencies`: List of other artifacts this one depends on. Useful for dependency management.
-* `build-job`: ID of any associated CI job/build pipeline.
-* `build-host`: Name/ID of machine that built the artifact.
-* `build-duration`: How long the build took. Performance metric.
-* `build-timestamp`: Exact UTC timestamp of when build occurred.
-* `artifact-hash`: Hash or checksum of the artifact output. Improves integrity checking.
-* `artifact-url`: Direct URL to download the artifact.
-* `artifact-notes`: Any other information about the build - logs, warnings, etc.
+- `artifact-outputs`: List of files or artifacts generated. Gives more insight
+  into what's included beyond just the tree prefix.
+- `artifact-dependencies`: List of other artifacts this one depends on. Useful
+  for dependency management.
+- `build-job`: ID of any associated CI job or build pipeline.
+- `build-host`: Name or ID of the machine that built the artifact.
+- `build-duration`: How long the build took. Performance metric.
+- `build-timestamp`: Exact UTC timestamp of when the build occurred.
+- `artifact-hash`: Hash or checksum of the artifact output. Improves integrity
+  checking.
+- `artifact-url`: Direct URL to download the artifact.
+- `artifact-notes`: Any other information about the build - logs, warnings, etc.
 
+## Usage example 1
 
-
-
-
-# Usage example 1
-```
+```bash
 git_recycle_bin.py \
     --path ../obj/doc/html \
     --name "Aurora-RST-Documentation" \
-    --remote git@gitlab.ci.demant.com:csfw/documentation/generated/aurora_rst_html_mpeddemo.git \
+    --remote git@gitlab.ci.demant.com:csfw/documentation/generated/\
+aurora_rst_html_mpeddemo.git \
     --push \
     --push-tag
 ```
 
 This will:
 
-  1. Create a new empty git repo locally -- to ensure non-interference with source repo.
-  2. Create a new binary artifact git commit for the HTML folder and assign it a {name, expiry} and record meta-data.
-  3. Push the artifact to the remote, as an orphan branch named `auto/artifact/firmware@ed6267ee5b84c894fc8490d93db0525fb2f167eb/{obj/doc/html}`
-     (if the branch already exists, we lost the push-race and leave it alone).
-  4. Push {a new, an update of} tag `auto/artifact/firmware@feature/wrk_le_audio_7.0/{obj/doc/html}`
-     (if the tag already exists, it will be updated if our committer time is more recent).
+1. Create a new empty git repo locally to ensure non-interference with the
+   source repo.
+2. Create a new binary artifact git commit for the HTML folder and assign it a
+   name and expiry while recording meta-data.
+3. Push the artifact to the remote, as an orphan branch named
+   `auto/artifact/firmware@ed6267ee5b84c894fc8490d93db0525fb2f167eb/{obj/doc/html}`
+   (if the branch already exists, we lost the push race and leave it alone).
+4. Push either a new or updated tag
+   `auto/artifact/firmware@feature/wrk_le_audio_7.0/{obj/doc/html}`
+   (if the tag already exists, it will be updated if our committer time is more
+   recent).

--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,8 @@ pkgs.mkShell {
   name = "git-recycle-bin";
   packages = [
     pkgs.just
+    pkgs.shellcheck
+    pkgs.markdownlint-cli
     git-recycle-bin
   ];
   shellHook = ''


### PR DESCRIPTION
## Summary
- reformat `AGENTS.md` with blank lines and wrapped text
- clean up `issues/0001-git-notes-integration.md`
- restructure README and split long command

## Testing
- `nix-shell shell.nix --pure --run "just shellcheck"`
- `nix-shell shell.nix --pure --run "just mdlint"`
- `nix-shell shell.nix --pure --run "just unittest"`


------
https://chatgpt.com/codex/tasks/task_e_684b33e87598832bb3fe366c9d7f9f9d