### PR TITLE
Enable coverage and CI badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
         env:
           TZ: Europe/Copenhagen
         run: nix-shell --pure --run "just unittest"
+      - uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
 
   pip_install:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ tmp/
 build/
 dist/
 git_recycle_bin.egg-info/
+.coverage
+coverage.xml
+htmlcov/

--- a/default.nix
+++ b/default.nix
@@ -17,9 +17,10 @@ pkgs.python311Packages.buildPythonApplication rec {
     colorama
     dateparser
     pytest
+    pytest-cov
   ];
 
-  checkInputs = with pkgs.python311Packages; [ pytest ];
+  checkInputs = with pkgs.python311Packages; [ pytest pytest-cov ];
 
   checkPhase = ''
     runHook preCheck

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 # Run unit tests
 unittest:
-    PYTHONPATH="$PYTHONPATH:$PWD:$PWD/src" pytest
+    PYTHONPATH="$PYTHONPATH:$PWD:$PWD/src" pytest --cov=src --cov-report=xml
 
 # Demonstrate help
 demo0:

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 # Git Recycle Bin ♻️
 
+[![CI](https://github.com/ArtifactLabs/git-recycle-bin/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/ArtifactLabs/git-recycle-bin/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/ArtifactLabs/git-recycle-bin/branch/master/graph/badge.svg)](https://codecov.io/gh/ArtifactLabs/git-recycle-bin)
+
 **Use any other git repo as an artifact build cache** 🤯.
 With bidirectional traceability 🎉!
 Store build outputs right alongside your source and skip costly rebuilds while


### PR DESCRIPTION
## Summary
- run pytest with coverage and upload to Codecov
- show build and coverage badges in the README
- ignore coverage artifacts
- revert coverage run from Nix build

## Testing
- `nix-shell shell.nix --pure --run "just unittest"`

------
https://chatgpt.com/codex/tasks/task_e_684b5bb424a4832bbbc0df9f60f75b5e