### PR TITLE
Add lint jobs with ShellCheck and markdownlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,21 @@ jobs:
       - uses: cachix/install-nix-action@v25
       - name: Demo download
         run: nix-shell --pure --run "just download::${{ matrix.demo }}"
+
+  lint-shell:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+      - name: ShellCheck
+        run: nix-shell --pure --run "just lint-shell"
+
+  lint-md:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+      - name: Markdownlint
+        run: nix-shell --pure --run "just lint-md"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,3 +81,15 @@ demo_download:
     matrix:
       - DEMO:
         - demo1
+
+lint_shell:
+  stage: test
+  script:
+    - nix-shell --pure --run "just lint-shell"
+  allow_failure: true
+
+lint_md:
+  stage: test
+  script:
+    - nix-shell --pure --run "just lint-md"
+  allow_failure: true

--- a/contribution.md
+++ b/contribution.md
@@ -8,3 +8,6 @@ Tickets should follow the style outlined in `AGENTS.md` with sections for
 purpose, acceptance criteria, prerequisites, questions and status.
 Follow the coding and testing conventions in `AGENTS.md` when submitting
 a pull request.
+
+Before opening a pull request, you can run `just lint` to check shell
+scripts with ShellCheck and Markdown files with `markdownlint`.

--- a/justfile
+++ b/justfile
@@ -13,3 +13,14 @@ mod push 'demos/push.justfile'
 mod list 'demos/list.justfile'
 mod clean 'demos/clean.justfile'
 mod download 'demos/download.justfile'
+
+# Lint shell scripts
+lint-shell:
+    find . -name '*.sh' -print0 | xargs -0 shellcheck
+
+# Lint Markdown files
+lint-md:
+    markdownlint '**/*.md'
+
+# Run all linters
+lint: lint-shell lint-md

--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,8 @@ pkgs.mkShell {
   packages = [
     pkgs.just
     git-recycle-bin
+    pkgs.shellcheck
+    pkgs.nodePackages.markdownlint-cli
   ];
   shellHook = ''
     export JUST_UNSTABLE=1


### PR DESCRIPTION
## Summary
- set up shellcheck and markdownlint in dev shell
- provide justfile rules to run them
- document lint command in contribution guide
- run lint in CI (allowed to fail)
- split lint jobs into separate shell and Markdown steps

## Testing
- `nix-shell --pure --run "just unittest"`


------
https://chatgpt.com/codex/tasks/task_e_684be835a8a4832bb758037986cbc42a