### PR TITLE
Fix markdown and shell lint issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,69 @@
 # Repo Guidelines for Codex Agents
 
-This project provides a collection of Python scripts and utilities for managing artifacts in a git repository.  It uses Nix for reproducible development environments but should remain runnable outside of Nix as a normal Python package.
+This project provides a collection of Python scripts and utilities for
+managing artifacts in a git repository.
+It uses Nix for reproducible development environments but should remain
+runnable outside of Nix as a normal Python package.
 
 ## Project Structure
+
 The repository is organised into a few key folders:
+
 - `src/` contains the application code and executable entrypoints.
 - `tests/` holds unit and future integration tests.
 - `demos/` shows practical usage of the tools.
 - `aux/` holds helper scripts that are not part of the build itself but may be
   useful.
-- `issues/` contains markdown tickets that track design ideas and
-  open tasks. When starting new work, add a ticket here first.
+- `issues/` contains markdown tickets that track design ideas and open tasks.
+  When starting new work, add a ticket here first.
 
 ### Issue ticket style
+
 Tickets under `issues/` should outline:
+
 - **Purpose** of the idea or feature
 - **Acceptance Criteria** describing what must be true to close the ticket
 - **Prerequisites** needed before work can begin
 - **Questions** that remain open
 - **Status** of the issue (e.g. Open, Done)
-Wrap lines in these markdown files at roughly 72 characters for
-readability.
+
+Wrap lines in these markdown files at roughly 72 characters for readability.
 
 ## Coding Conventions
+
 - Follow PEP 8 style with four-space indentation and descriptive names.
 - Use type hints where sensible and keep functions short and readable.
 - Prefer standard library modules over additional dependencies when possible.
 - Use `snake_case` for modules and functions, and `PascalCase` for classes.
 
 ## General Conventions for AGENTS.md Implementation
-- Keep this document in sync with the code base. Update guidelines alongside feature or behaviour changes.
-- Clarify any new requirements or conventions in this file so agents know how to contribute.
+
+- Keep this document in sync with the code base.
+  Update guidelines alongside feature or behaviour changes.
+- Clarify any new requirements or conventions in this file so agents know how
+  to contribute.
 
 ## Testing Requirements
+
 - Preferred: `nix-shell shell.nix --pure --run "just unittest"`.
-- Non-Nix: install dependencies from `setup.py` and run `pytest` with `PYTHONPATH=$PWD:$PWD/src`.
-- Integration tests comparing HEAD with prior tagged releases must pass before merging breaking behaviour changes.
+- Non-Nix: install dependencies from `setup.py` and run `pytest` with
+  `PYTHONPATH=$PWD:$PWD/src`.
+- Integration tests comparing HEAD with prior tagged releases must pass
+  before merging breaking behaviour changes.
 
 ## Environment
+
 - Code should run with Python 3.11+. Avoid Nix-specific runtime assumptions.
 - Ensure the project remains installable with `pip install .`.
 
 ## Style and Quality
-- Keep the code base robust and industrial readable. Use type hints and descriptive names.
-- Avoid breaking changes. Introduce integration tests comparing HEAD with previous tagged releases when altering behaviour.
-- Keep documentation and design notes in sync with the implementation to avoid drift.
+
+- Keep the code base robust and industrial readable. Use type hints and
+  descriptive names.
+- Avoid breaking changes. Introduce integration tests comparing HEAD with
+  previous tagged releases when altering behaviour.
+- Keep documentation and design notes in sync with the implementation to avoid
+  drift.
 - Wrap lines in Markdown to keep them reasonably short and readable.
 - Embrace the UNIX and KISS philosophies and apply POLA (principle of least
   astonishment).
@@ -53,15 +72,20 @@ readability.
   end-to-end tests exist and add unit tests.
 
 ## Pull Request Guidelines
+
 - Keep PRs focused and include a summary of changes and testing steps.
 - Ensure programmatic checks pass locally before opening a PR.
 
 ## Programmatic Checks
-- Run `nix-shell shell.nix --pure --run "just unittest"` and ensure all tests succeed.
+
+- Run `nix-shell shell.nix --pure --run "just unittest"` and ensure all tests
+  succeed.
 - Validate that documentation updates accompany code changes to prevent drift.
 
 ## Continuous Integration
-The project maintains both GitHub and GitLab pipelines. When changing one CI
-configuration, update the other in a comparable manner so the steps remain
-logically aligned. Keep `.gitlab-ci.yml` and `.github/workflows/ci.yml`
-synchronized to avoid divergent behaviour.
+
+The project maintains both GitHub and GitLab pipelines.
+When changing one CI configuration, update the other in a comparable manner so
+the steps remain logically aligned.
+Keep `.gitlab-ci.yml` and `.github/workflows/ci.yml` synchronized to avoid
+divergent behaviour.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,14 @@ To keep the project easy to work with please follow these steps:
    cd git-recycle-bin
    git checkout -b my-feature origin/master
    ```
-2. **Coding style** follows PEP 8 with four-space indents and type hints where useful.
+
+2. **Coding style** follows PEP 8 with four-space indents
+   and type hints where useful.
 3. **Run tests locally**:
    - Preferred: `nix-shell shell.nix --pure --run "just unittest"`
    - Non‑Nix: `pip install .` then `PYTHONPATH=$PWD:$PWD/src pytest`
-4. **Open a pull request** with a short summary of your changes and how you tested them.
+4. **Open a pull request** with a short summary of your changes and how you
+   tested them.
 
 Please also read `AGENTS.md` for repository etiquette.
 
@@ -24,4 +27,5 @@ Please also read `AGENTS.md` for repository etiquette.
 Nix gives you a fully reproducible build environment. Follow the official
 [installation guide](https://nixos.org/download.html) if you don't have it yet.
 
-All kinds of improvements are welcome – documentation, tests or features. Happy hacking! 🚀
+All kinds of improvements are welcome – documentation, tests or features.
+Happy hacking! 🚀

--- a/aux/git_add_ssh_remote.sh
+++ b/aux/git_add_ssh_remote.sh
@@ -58,4 +58,4 @@ else
     git remote add "${REMOTE_NAME}_ssh" "$ssh_url" 2>/dev/null || true
 fi
 
-echo "Remote '${REMOTE_NAME}_ssh' added: $(git remote get-url ${REMOTE_NAME}_ssh)" 1>&2
+echo "Remote '${REMOTE_NAME}_ssh' added: $(git remote get-url "${REMOTE_NAME}_ssh")" 1>&2

--- a/issues/0001-git-notes-integration.md
+++ b/issues/0001-git-notes-integration.md
@@ -1,10 +1,12 @@
 # Git notes integration for artifact discovery
 
 ## Purpose
+
 Allow discovery of binary artifacts by storing metadata under
 `git notes`.
 
 ## Acceptance Criteria
+
 - Dedicated namespace such as `refs/notes/artifact/<TARGET>` or
   `refs/notes/artifact/<BIN_REMOTE>/<TARGET>` stores a note for each
   relevant commit.
@@ -14,11 +16,14 @@ Allow discovery of binary artifacts by storing metadata under
 - CLI commands expose creation and reading of notes.
 
 ## Prerequisites
+
 - Familiarity with `git notes` and the project's artifact scheme.
 
 ## Questions
+
 - Should notes also capture artifact expiry information?
 
 ## Status
+
 Done. Implementation was completed in commit `5ef2128` and described
 in `design_notes.txt`.

--- a/issues/0002-gitlfs-support.md
+++ b/issues/0002-gitlfs-support.md
@@ -1,19 +1,24 @@
 # Support for GitLFS and garbage collection
 
 ## Purpose
+
 Explore storing artifacts with GitLFS and understand how LFS objects can
 be cleaned up when artifacts expire.
 
 ## Acceptance Criteria
+
 - Describe how GitLFS performs garbage collection.
 - Provide commands that remove unused LFS objects together with the
   orphan-branch cleanup.
 
 ## Prerequisites
+
 - GitLFS installed and configured in the development environment.
 
 ## Questions
+
 - Does GitLFS need explicit pruning or is it handled automatically?
 
 ## Status
+
 Open

--- a/issues/0003-non-orphan-lineage.md
+++ b/issues/0003-non-orphan-lineage.md
@@ -1,18 +1,23 @@
 # Non-orphan branch lineage preservation
 
 ## Purpose
+
 Allow artifact branches to retain the source commit as their parent so the
 relationship between source and artifact is visible in normal history.
 
 ## Acceptance Criteria
+
 - New option to create artifact branches with a parent commit.
 - Lineage clearly shown when running standard git history commands.
 
 ## Prerequisites
+
 - Understanding of how orphan branches are currently produced.
 
 ## Questions
+
 - Should lineage branches be enabled by default or remain optional?
 
 ## Status
+
 Open

--- a/issues/0004-non-expiring-artifacts.md
+++ b/issues/0004-non-expiring-artifacts.md
@@ -1,18 +1,23 @@
 # Support for non-expiring artifacts
 
 ## Purpose
-Keep certain artifacts forever, acting as releases or long term
+
+Keep certain artifacts forever, acting as releases or long-term
 checkpoints that never expire.
 
 ## Acceptance Criteria
+
 - Command line flag or configuration to mark an artifact as permanent.
 - Garbage collection leaves these artifacts intact.
 
 ## Prerequisites
+
 - Current pruning mechanism based on absolute expiry dates.
 
 ## Questions
+
 - Should permanent artifacts be stored in a separate namespace?
 
 ## Status
+
 Open

--- a/issues/0005-library-support.md
+++ b/issues/0005-library-support.md
@@ -1,19 +1,24 @@
 # Convert tools into a reusable library
 
 ## Purpose
+
 Make the artifact management functionality available as an importable
 library so other projects can reuse it programmatically.
 
 ## Acceptance Criteria
+
 - Package exposes stable APIs for listing, pushing and cleaning
   artifacts.
 - CLI continues to operate using those APIs.
 
 ## Prerequisites
+
 - Codebase currently implemented as command line scripts.
 
 ## Questions
+
 - Which parts of the API need to remain backwards compatible?
 
 ## Status
+
 Open

--- a/issues/0006-ui-queries-overview.md
+++ b/issues/0006-ui-queries-overview.md
@@ -1,19 +1,24 @@
 # Extended user interface for queries and overview
 
 ## Purpose
+
 Improve visibility into stored artifacts with commands that list them
 and summarise repository status.
 
 ## Acceptance Criteria
+
 - CLI can display available artifacts for a commit or branch.
 - Users can query upcoming expiries.
 - Overview command summarises repository health.
 
 ## Prerequisites
+
 - Basic list and push commands already implemented.
 
 ## Questions
+
 - Should the overview command display remote configuration details?
 
 ## Status
+
 Open

--- a/issues/0007-python-test-matrix.md
+++ b/issues/0007-python-test-matrix.md
@@ -1,20 +1,25 @@
 # Python version test matrix
 
 ## Purpose
+
 Ensure the project works across multiple Python versions by
 running automated tests against a matrix of versions.
 
 ## Acceptance Criteria
+
 - CI configuration runs tests on at least three supported
   Python releases.
 - Failures on any version block merges.
 
 ## Prerequisites
+
 - Tests runnable in a clean environment.
 
 ## Questions
+
 - Which versions should be considered the minimum
   supported set?
 
 ## Status
+
 Open

--- a/issues/0008-prepare-for-pypi.md
+++ b/issues/0008-prepare-for-pypi.md
@@ -1,20 +1,25 @@
 # Prepare project for PyPI upload
 
 ## Purpose
+
 Package the code for publication on PyPI so it can be easily
 installed via `pip`.
 
 ## Acceptance Criteria
+
 - Build configuration produces a valid source distribution and
   wheel.
 - Metadata such as description and license render correctly on
   PyPI.
 
 ## Prerequisites
+
 - Complete versioning strategy and test coverage.
 
 ## Questions
+
 - Should we use `twine` or another tool for uploading?
 
 ## Status
+
 Open

--- a/issues/0009-versioning-strategy.md
+++ b/issues/0009-versioning-strategy.md
@@ -1,18 +1,23 @@
 # Versioning and release strategy
 
 ## Purpose
+
 Define how the project bumps versions for releases and how
 pre-release builds are labelled.
 
 ## Acceptance Criteria
+
 - Automated process updates version numbers when releasing.
 - Strategy documented for patch, minor and major bumps.
 
 ## Prerequisites
+
 - Continuous integration and packaging tools in place.
 
 ## Questions
+
 - Should we follow semantic versioning or a simpler scheme?
 
 ## Status
+
 Open

--- a/issues/0010-stress-testing.md
+++ b/issues/0010-stress-testing.md
@@ -1,19 +1,24 @@
 # Stress testing under heavy load
 
 ## Purpose
+
 Evaluate behaviour when many clients push and pull artifacts
 in parallel to uncover race conditions in expiration logic.
 
 ## Acceptance Criteria
+
 - Tests simulate concurrent producers and consumers with
   expiring artifacts.
 - System remains stable and cleans up expired data correctly.
 
 ## Prerequisites
+
 - Functioning concurrency in existing commands.
 
 ## Questions
+
 - How should we coordinate workers to trigger potential races?
 
 ## Status
+
 Open

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@ You can also install from a local checkout with:
 ```bash
 pip install .
 ```
+
 (tested in CI 🎉)
 
 ## Quick start
@@ -63,8 +64,9 @@ Push an artifact to a binary repository:
 git_recycle_bin.py push \
     git@example.com:documentation/generated/rst_html.git \
     --path ../obj/doc/html \
-    --name "Example-RST-Documentation" --tag
+--name "Example-RST-Documentation" --tag
 ```
+
 Push with expiry:
 
 ```bash
@@ -77,6 +79,7 @@ Download an artifact back into your working tree:
 git_recycle_bin.py list . | head -n 1 | \
     xargs -I _ git_recycle_bin.py download . _
 ```
+
 List artifacts:
 
 ```bash
@@ -96,14 +99,13 @@ CI pipelines can fetch a matching artifact and skip rebuilding altogether.
 
 Artifacts include metadata stored as trailer fields in the commit message. Key fields:
 
-* `artifact-schema-version`
-* `artifact-name`
-* `artifact-mime-type`
-* `artifact-tree-prefix`
-* `src-git-relpath`
-* `src-git-commit-sha`
-* `src-git-branch`
-* `src-git-repo-url`
+- `artifact-schema-version`
+- `artifact-name`
+- `artifact-mime-type`
+- `artifact-tree-prefix`
+- `src-git-relpath`
+- `src-git-commit-sha`
+- `src-git-branch`
+- `src-git-repo-url`
 
 For a full schema see [issue #1](issues/0001-git-notes-integration.md).
-


### PR DESCRIPTION
## Summary
- correct shellcheck warning in git_add_ssh_remote.sh
- tidy markdown files to satisfy markdownlint
- wrap lines and add spacing in AGENTS instructions
- adjust CONTRIBUTING and README for linter compliance

## Testing
- `pip install -e .`
- `PYTHONPATH=$PWD:$PWD/src pytest -q`
- `markdownlint '**/*.md'`
- `find . -name '*.sh' -print0 | xargs -0 shellcheck`


------
https://chatgpt.com/codex/tasks/task_e_684c27a604c8832ba7d354929b912891