### PR TITLE
Update lint guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Wrap lines in these markdown files at roughly 72 characters for readability.
 ## Testing Requirements
 
 - Preferred: `nix-shell shell.nix --pure --run "just unittest"`.
+- Always run `nix-shell --run 'just lint'` to verify code style.
 - Non-Nix: install dependencies from `setup.py` and run `pytest` with
   `PYTHONPATH=$PWD:$PWD/src`.
 - Integration tests comparing HEAD with prior tagged releases must pass
@@ -80,6 +81,7 @@ Wrap lines in these markdown files at roughly 72 characters for readability.
 
 - Run `nix-shell shell.nix --pure --run "just unittest"` and ensure all tests
   succeed.
+- Run `nix-shell --run 'just lint'` and fix any reported issues.
 - Validate that documentation updates accompany code changes to prevent drift.
 
 ## Continuous Integration


### PR DESCRIPTION
## Summary
- instruct devs to run nix-shell just lint in AGENTS doc

## Testing
- `nix-shell --run 'just lint'`
- `nix-shell shell.nix --pure --run "just unittest"`

------
https://chatgpt.com/codex/tasks/task_e_684c4b70230c832bb93917dcb52446de