### PR TITLE
Add Codecov uploads in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,11 @@ jobs:
         env:
           TZ: Europe/Copenhagen
         run: nix-shell --pure --run "just unittest"
-      - uses: codecov/codecov-action@v4
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ArtifactLabs/git-recycle-bin
           files: coverage.xml
 
   pip_install:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,9 @@ unittest:
   stage: test
   script:
     - nix-shell --pure --run "just unittest"
+    - curl -Os https://uploader.codecov.io/latest/linux/codecov
+    - chmod +x codecov
+    - ./codecov -t ${CODECOV_TOKEN} -r ArtifactLabs/git-recycle-bin -f coverage.xml
 
 pip_install:
   stage: test


### PR DESCRIPTION
## Summary
- upload coverage to Codecov from GitHub Actions
- upload coverage to Codecov from GitLab CI

## Testing
- `nix-shell --run 'just lint'`
- `nix-shell shell.nix --pure --run 'just unittest'`

------
https://chatgpt.com/codex/tasks/task_e_684c28282344832b955d6fe294faf847