### PR TITLE
Update README examples and clarify agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ Wrap lines in these markdown files at roughly 72 characters for readability.
   succeed.
 - Run `nix-shell --run 'just lint'` and fix any reported issues.
 - Validate that documentation updates accompany code changes to prevent drift.
+- When editing CLI examples, run `git_recycle_bin.py --help` to verify option
+  names and arguments.
 
 ## Continuous Integration
 

--- a/issues/0011-sibling-demo-src-bin-projects.md
+++ b/issues/0011-sibling-demo-src-bin-projects.md
@@ -1,0 +1,23 @@
+# Sibling demo projects for source and binary repos
+
+## Purpose
+
+Provide example projects that demonstrate using git-recycle-bin with
+separate source and artifact repositories.
+
+## Acceptance Criteria
+
+- Two small repositories illustrate pushing and fetching artifacts.
+- README files explain how to run the demo end-to-end.
+
+## Prerequisites
+
+- Working installation of git-recycle-bin.
+
+## Questions
+
+- Should the demos use Makefiles or plain shell scripts?
+
+## Status
+
+Open

--- a/readme.md
+++ b/readme.md
@@ -8,19 +8,59 @@ With bidirectional traceability 🎉!
 Store build outputs right alongside your source and skip costly rebuilds while
 keeping complete traceability.
 
+## What is Git Recycle Bin?
+
+Git Recycle Bin uses Git so you can manage build artifacts in a
+separate repository while keeping a clear link back to the source that
+produced them. Artifacts can be pushed, fetched and automatically
+removed when they expire.
+
+## Features
+
+- Push build outputs to a dedicated artifact repository
+- Preserve metadata linking artifacts back to the exact source commit
+- Garbage collect artifacts using expiry dates
+- Create `latest` tags for easy discovery
+- Enable skipping builds by downloading pre-built artifacts
+- Use git-notes so source repos know which binaries exist
+- Operates locally or with any remote Git server using your existing git+ssh
+  authentication
+- Requires no additional setup or deployment of other services so you can use
+  your existing Git infrastructure
+
 ## Why adopt?
 
-- 🌱 *Self-governed*: no special server software or enterprise tools required.
-  Any git host works.
-- ♻️ *Reuse binaries*: retrieve previous build artifacts and avoid unnecessary rebuilds.
-- 🔍 *Full traceability*: artifacts are tied to the exact source commit via git notes.
+- 🌱 *Self-governed*: no special server software or enterprise tools
+  required. Any git host works.
+- ♻️ *Reuse binaries*: retrieve previous build artifacts and avoid
+  unnecessary rebuilds.
+- 🔍 *Full traceability*: artifacts are tied to the exact source commit
+  via git notes.
 - 🗑️ *Garbage collect*: expired artifacts vanish with `git gc`.
+
+## Principle of Operation
+
+Artifacts are stored in orphan branches using a structured naming
+scheme:
+
+```text
+artifact/expire/{EXPIRY_DATE}/{SOURCE_REPO}@{SOURCE_SHA}/{ARTIFACT_PATH}
+```
+
+`latest` tags point at the most recent artifact for a branch:
+
+```text
+artifact/latest/{SOURCE_REPO}@{SOURCE_BRANCH}/{ARTIFACT_PATH}
+```
+
+Metadata-only refs allow querying
+information without downloading the full artifact tree. Git notes on
+source commits advertise available artifacts and are used to implement
+build avoidance.
 
 ## Installation
 
 ### Using Nix
-
-Add this package in a development shell using `callPackage`:
 
 ```nix
 { pkgs ? import <nixpkgs> {} }:
@@ -29,8 +69,8 @@ pkgs.mkShell {
     (pkgs.callPackage (pkgs.fetchFromGitHub {
       owner = "artifactLabs";
       repo = "git-recycle-bin";
-      rev = "<commit>";   # pin a specific tag or commit
-      sha256 = "<hash>";   # update this hash
+      rev = "<commit>";
+      sha256 = "<hash>";
     } + "/default.nix") {})
   ];
 }
@@ -48,15 +88,13 @@ nix-shell
 pip install git+https://github.com/ArtifactLabs/git-recycle-bin.git
 ```
 
-You can also install from a local checkout with:
+You can also install from a local checkout:
 
 ```bash
 pip install .
 ```
 
-(tested in CI 🎉)
-
-## Quick start
+## Basic usage
 
 Push an artifact to a binary repository:
 
@@ -64,7 +102,7 @@ Push an artifact to a binary repository:
 git_recycle_bin.py push \
     git@example.com:documentation/generated/rst_html.git \
     --path ../obj/doc/html \
---name "Example-RST-Documentation" --tag
+    --name "Example-RST-Documentation" --tag
 ```
 
 Push with expiry:
@@ -86,18 +124,44 @@ List artifacts:
 git_recycle_bin.py list . --name "Example-RST-Documentation"
 ```
 
+Enable build avoidance in your build script by checking for an existing
+artifact before building:
+
+```bash
+if git_recycle_bin.py list . --name demo | grep -q .; then
+    git_recycle_bin.py list . --name demo | head -n 1 | \
+        xargs -I _ git_recycle_bin.py download . _
+    echo "Build skipped - using downloaded artifact"
+else
+    make all
+    git_recycle_bin.py push . --path ./build --name demo
+fi
+```
+
+## Advanced usage
+
+Set a custom expiry date when pushing an artifact:
+
+```bash
+git_recycle_bin.py push . --path ./build --name demo --expire "1 month"
+```
+
+List all artifacts for the current repository:
+
+```bash
+git_recycle_bin.py list .
+```
+
 ## How it works
 
-`git-recycle-bin` stores artifacts in dedicated branches and links them to source
-commits using git notes.
-Because notes are non-destructive, you can look up previous binaries and reuse them.
-The name comes from the ability to recycle artifacts.
-Stale ones can be removed when no longer needed.
-CI pipelines can fetch a matching artifact and skip rebuilding altogether.
+`git-recycle-bin` stores artifacts in dedicated branches and
+links them to source commits using git notes. Notes are non-destructive
+so you can look up previous binaries and reuse them. Stale artifacts
+disappear once expired and a `git gc` runs. CI pipelines can fetch
+matching artifacts and skip rebuilding.
 
-## Technical details
-
-Artifacts include metadata stored as trailer fields in the commit message. Key fields:
+Artifacts include metadata stored as trailer fields in the commit
+message. Key fields:
 
 - `artifact-schema-version`
 - `artifact-name`
@@ -109,3 +173,10 @@ Artifacts include metadata stored as trailer fields in the commit message. Key f
 - `src-git-repo-url`
 
 For a full schema see [issue #1](issues/0001-git-notes-integration.md).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. Run tests
+with `just unittest` and check style with `just lint`
+before submitting a
+pull request.


### PR DESCRIPTION
## Summary
- fix README examples to use valid CLI options
- remove non-existent update-notes example
- show how to check for existing artifacts before building
- document verifying CLI usage in AGENTS guidelines

## Testing
- `nix-shell shell.nix --pure --run "just unittest"`
- `nix-shell --run 'just lint'`

------
https://chatgpt.com/codex/tasks/task_e_684c8c2b97b0832bb68fb54856b528de