### PR TITLE
Add SonarCloud badges

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,9 @@
 
 [![CI](https://github.com/ArtifactLabs/git-recycle-bin/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/ArtifactLabs/git-recycle-bin/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/ArtifactLabs/git-recycle-bin/branch/master/graph/badge.svg)](https://codecov.io/gh/ArtifactLabs/git-recycle-bin)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ArtifactLabs_git-recycle-bin&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=ArtifactLabs_git-recycle-bin)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ArtifactLabs_git-recycle-bin&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=ArtifactLabs_git-recycle-bin)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ArtifactLabs_git-recycle-bin&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=ArtifactLabs_git-recycle-bin)
 
 **Use any other git repo as an artifact build cache** 🤯.
 With bidirectional traceability 🎉!


### PR DESCRIPTION
## Summary
- add Security, Maintainability and Reliability badges to README

## Testing
- `nix-shell shell.nix --pure --run "just unittest"`
- `nix-shell --run 'just lint'`


------
https://chatgpt.com/codex/tasks/task_e_684ca92ff964832b950bf94e9a18209b