### PR TITLE
Refactor imports

### DIFF
--- a/src/commit_msg.py
+++ b/src/commit_msg.py
@@ -1,4 +1,12 @@
-from util_string import *
+import re
+
+from util_string import (
+    prefix_lines,
+    remove_empty_lines,
+    string_trunc_ellipsis,
+    trim_all_lines,
+    url_redact,
+)
 
 
 def extract_gerrit_change_id(commit_message: str) -> str:

--- a/src/git_recycle_bin.py
+++ b/src/git_recycle_bin.py
@@ -8,13 +8,30 @@ from collections import OrderedDict
 
 from rbgit import RbGit
 from printer import printer
-from util_string import *
-from util_file import *
-from util_date import *
-from util_sysinfo import *
-from util import *
-from arg_parser import *
-from commit_msg import *
+from util_string import (
+    prefix_lines,
+    sanitize_branch_name,
+    sanitize_slashes,
+    string_trunc_ellipsis,
+    trim_all_lines,
+    url_redact,
+)
+from util_file import nca_path, rel_dir, classify_path
+from util_date import (
+    DATE_FMT_GIT,
+    DATE_FMT_EXPIRE,
+    date_fuzzy2expiryformat,
+    date_formatted2unix,
+    date_parse_formatted,
+    format_timespan,
+    parse_expire_date,
+)
+from dateutil.tz import tzlocal
+import datetime
+from util_sysinfo import get_user, get_hostname
+from util import exec, exec_nostderr
+from arg_parser import parse_args
+from commit_msg import emit_commit_msg, parse_commit_msg, extract_gerrit_change_id
 
 # commands
 from list import list_command

--- a/src/list.py
+++ b/src/list.py
@@ -1,7 +1,7 @@
 from printer import printer
-from commit_msg import *
 from util import exec
-from util_string import *
+from util_string import sanitize_branch_name
+from commit_msg import parse_commit_msg
 
 
 def list_command(args, rbgit, remote_bin_name):


### PR DESCRIPTION
## Summary
- remove wildcard imports in `commit_msg`, `list`, and `git_recycle_bin`
- import only required names from helper modules

## Testing
- `nix-shell shell.nix --pure --run "just unittest"`
- `nix-shell --run 'just lint'`

------
https://chatgpt.com/codex/tasks/task_e_684caf610ad0832b90e9b3194fe94c62