### PR TITLE
Add Sphinx documentation and pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,18 @@ jobs:
       - name: Markdownlint
         run: nix-shell --pure --run "just lint-md"
 
+  docs-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+      - name: Validate docs
+        run: nix-shell --pure --run "just docs-lint"
+
   pages:
     runs-on: ubuntu-latest
     needs: unittest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,21 @@ jobs:
       - uses: cachix/install-nix-action@v25
       - name: Markdownlint
         run: nix-shell --pure --run "just lint-md"
+
+  pages:
+    runs-on: ubuntu-latest
+    needs: unittest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+      - name: Build docs
+        run: nix-shell --pure --run "just docs"
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/_build/html
+      - uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ git_recycle_bin.egg-info/
 .coverage
 coverage.xml
 htmlcov/
+docs/_build/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,6 +111,11 @@ lint_md:
     - nix-shell --pure --run "just lint-md"
   allow_failure: true
 
+docs_lint:
+  stage: test
+  script:
+    - nix-shell --pure --run "just docs-lint"
+
 pages:
   stage: deploy
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
   - test
   - demos
+  - deploy
 
 variables:
   NIX_PATH: "nixpkgs=channel:nixos-24.05"
@@ -109,3 +110,13 @@ lint_md:
   script:
     - nix-shell --pure --run "just lint-md"
   allow_failure: true
+
+pages:
+  stage: deploy
+  script:
+    - nix-shell --pure --run "just docs"
+  artifacts:
+    paths:
+      - docs/_build/html
+  only:
+    - master

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('../src'))
+
+project = 'git-recycle-bin'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+]
+
+autodoc_member_order = 'bysource'
+
+html_theme = 'sphinx_material'
+html_theme_options = {
+    'nav_title': 'git-recycle-bin Documentation',
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,3 +16,16 @@ html_theme = 'sphinx_material'
 html_theme_options = {
     'nav_title': 'git-recycle-bin Documentation',
 }
+html_context = {}
+
+# Prevent sphinx_material from inserting unpicklable objects in html_context
+try:
+    import sphinx_material
+
+    def setup(app):
+        sphinx_material.setup(app)
+        def _clear_context(app, env):
+            env.config.html_context = {}
+        app.connect("env-updated", _clear_context)
+except Exception:
+    pass

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,8 @@
+Welcome to git-recycle-bin's documentation!
+===========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,8 @@
+API Reference
+=============
+
+.. automodule:: git_recycle_bin
+   :members:
+
+.. automodule:: rbgit
+   :members:

--- a/justfile
+++ b/justfile
@@ -24,3 +24,9 @@ lint-md:
 
 # Run all linters
 lint: lint-shell lint-md
+
+# Build Sphinx documentation
+# Output goes to docs/_build/html
+# Use PYTHONPATH so autodoc can find modules
+docs:
+    PYTHONPATH="$PYTHONPATH:$PWD:$PWD/src" sphinx-build -b html docs docs/_build/html

--- a/justfile
+++ b/justfile
@@ -30,3 +30,8 @@ lint: lint-shell lint-md
 # Use PYTHONPATH so autodoc can find modules
 docs:
     PYTHONPATH="$PYTHONPATH:$PWD:$PWD/src" sphinx-build -b html docs docs/_build/html
+
+# Lint documentation with Sphinx
+# Treat warnings as errors to catch broken references
+docs-lint:
+    PYTHONPATH="$PYTHONPATH:$PWD:$PWD/src" sphinx-build -n -W -b dummy docs docs/_build/dummy

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,8 @@ With bidirectional traceability 🎉!
 Store build outputs right alongside your source and skip costly rebuilds while
 keeping complete traceability.
 
+Full documentation is available on [GitHub Pages](https://artifactlabs.github.io/git-recycle-bin/).
+
 ## What is Git Recycle Bin?
 
 Git Recycle Bin uses Git so you can manage build artifacts in a

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,8 @@ pkgs.mkShell {
     git-recycle-bin
     pkgs.shellcheck
     pkgs.nodePackages.markdownlint-cli
+    pkgs.python311Packages.sphinx
+    pkgs.python311Packages.sphinx-material
   ];
   shellHook = ''
     export JUST_UNSTABLE=1


### PR DESCRIPTION
## Summary
- set up Sphinx docs with sphinx-material theme
- provide `just docs` recipe and include Sphinx in shell.nix
- publish docs to GitHub Pages via CI
- keep GitLab pipeline aligned
- link to docs from README

## Testing
- `nix-shell --run 'just lint'`
- `nix-shell shell.nix --pure --run "just unittest"`
- `nix-shell --run 'just docs'`


------
https://chatgpt.com/codex/tasks/task_e_684d0887f4b8832ba40984940d3a0d3f