### PR TITLE
Fix small typos

### DIFF
--- a/design_notes.txt
+++ b/design_notes.txt
@@ -102,7 +102,7 @@ Implementing download.
            It is likely that different kinds of artifacts may be pushed to different remotes. E.g. HTML vs ELF.
            I.e. this is not discoverable.
 
-        b) Look for avilable git notes.
+        b) Look for available git notes.
            Run from within SRC_REPO:
            $ git fetch origin "refs/notes/*:refs/notes/*"
 

--- a/src/git_recycle_bin.py
+++ b/src/git_recycle_bin.py
@@ -65,9 +65,9 @@ def create_artifact_commit(rbgit, artifact_name: str, binpath: str, expire_branc
     # Author time is easily set with `git commit --date`.
     d['src_time_author']  = exec(["git", "show", "-s", "--format=%ad", f"--date=format:{DATE_FMT_GIT}", d['src_sha']])
 
-    # Commiter time changes every time the commit-SHA changes, for example {rebasing, amending, ...}.
-    # Commiter time can be set with $GIT_COMMITTER_DATE or `git rebase --committer-date-is-author-date`.
-    # Commiter time is monotonically increasing but sampled locally, so graph could still be non-monotonic if a collaborator has a very wrong clock.
+    # Committer time changes every time the commit-SHA changes, for example {rebasing, amending, ...}.
+    # Committer time can be set with $GIT_COMMITTER_DATE or `git rebase --committer-date-is-author-date`.
+    # Committer time is monotonically increasing but sampled locally, so graph could still be non-monotonic if a collaborator has a very wrong clock.
     d['src_time_commit']  = exec(["git", "show", "-s", "--format=%cd", f"--date=format:{DATE_FMT_GIT}", d['src_sha']])
 
     d['src_branch']       = exec(["git", "rev-parse", "--abbrev-ref", "HEAD"])


### PR DESCRIPTION
## Summary
- fix spelling in design notes
- correct spelling of "committer" in main script comments

## Testing
- `nix-shell shell.nix --pure --run "just unittest"`
- `nix-shell --run 'just lint'`

------
https://chatgpt.com/codex/tasks/task_e_684eb8d7e3dc832b86627e7a7772617c