### PR TITLE
Fix docs build by restoring theme context

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,8 +24,10 @@ try:
 
     def setup(app):
         sphinx_material.setup(app)
+
         def _clear_context(app, env):
-            env.config.html_context = {}
+            env.config.html_context = sphinx_material.get_html_context()
+
         app.connect("env-updated", _clear_context)
 except Exception:
     pass


### PR DESCRIPTION
## Summary
- address docs build failure by keeping `table_fix` filter in context
- adjust docs build configuration to preserve sphinx-material context

## Testing
- `nix-shell --run 'just lint'`
- `nix-shell --pure --run "just unittest"`
- `nix-shell --pure --run "just docs"`
- `nix-shell --pure --run "just docs-lint"`

------
https://chatgpt.com/codex/tasks/task_e_685033b8cf0c832bb9036bf2b51f87c7