### PR TITLE
Fix doc-lint caching issue

### DIFF
--- a/justfile
+++ b/justfile
@@ -34,4 +34,4 @@ docs:
 # Lint documentation with Sphinx
 # Treat warnings as errors to catch broken references
 docs-lint:
-    PYTHONPATH="$PYTHONPATH:$PWD:$PWD/src" sphinx-build -n -W -b dummy docs docs/_build/dummy
+    PYTHONPATH="$PYTHONPATH:$PWD:$PWD/src" sphinx-build -E -n -W -b dummy docs docs/_build/dummy


### PR DESCRIPTION
## Summary
- update docs-lint recipe to disable caching

## Testing
- `nix-shell shell.nix --pure --run "just unittest"`
- `nix-shell --run 'just lint'`
- `nix-shell --pure --run "just docs-lint"`


------
https://chatgpt.com/codex/tasks/task_e_68506c5e0fc8832b891941a454a942ae