### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   NIX_PATH: "nixpkgs=channel:nixos-24.05"
 


### PR DESCRIPTION
Potential fix for [https://github.com/ArtifactLabs/git-recycle-bin/security/code-scanning/11](https://github.com/ArtifactLabs/git-recycle-bin/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for all jobs. This will ensure that the `GITHUB_TOKEN` has only the necessary permissions. Since most jobs in the workflow involve reading repository contents, we will set `contents: read` as the default permission. For jobs that require additional permissions, such as the `pages` job, we will retain their specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
