### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   NIX_PATH: "nixpkgs=channel:nixos-24.05"
 
@@ -61,6 +64,8 @@ jobs:
 
   demo_push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       matrix:
         demo: [demo1, demo1_quiet, demo1_verbose, demo1_vverbose, demo2, demo3, demo4, demo5]


### PR DESCRIPTION
Potential fix for [https://github.com/ArtifactLabs/git-recycle-bin/security/code-scanning/1](https://github.com/ArtifactLabs/git-recycle-bin/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `contents: write` for jobs that might modify repository contents (e.g., `demo_push`).
- `pull-requests: write` for jobs interacting with pull requests (if applicable).

We will apply `contents: read` at the root level and override it with job-specific permissions where necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
